### PR TITLE
feat: scaffold Biblioteca Esotérica web platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# openai
-prueba
+# Biblioteca Esotérica – Lentes de Interpretación
+
+Plataforma conceptual construida con Next.js (SSR) y TypeScript para explorar versículos bíblicos con seis lentes interpretativos
+(literal, histórico-crítica, alegórica-tipológica, moral, esotérica y sod) manteniendo la trazabilidad entre Dato y Tradición.
+
+## Características
+
+- Rutas principales: `/login`, `/`, `/leer`, `/versiculo/[...refParts]`, `/cuaderno`.
+- API Routes para búsqueda, versículos, lentes, glosario, cuaderno, exportación PDF y borradores asistidos.
+- Patrón Repository con adaptadores InMemory (activo), Supabase y Postgres listos para configuración.
+- Límite de 3 búsquedas diarias por usuario con contador visible y respuestas HTTP 429.
+- Exportación de versículo + lentes a PDF mediante `pdfkit`.
+- Semillas mínimas: Juan 3 y Números 21 en RVR1909, glosario y seis lentes publicados.
+
+## Scripts
+
+```
+npm run dev
+npm run build
+npm run start
+npm run lint
+```
+
+> Nota: el entorno actual no incluye las dependencias instaladas debido a restricciones de red. Ejecuta `npm install` antes de
+iniciar los scripts en tu máquina local.

--- a/app/api/auth/callback/route.ts
+++ b/app/api/auth/callback/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  return NextResponse.json({ status: 'ok' });
+}

--- a/app/api/auth/login-google/route.ts
+++ b/app/api/auth/login-google/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { defaultUser } from '@/data/seeds';
+
+export async function GET(request: Request) {
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? new URL(request.url).origin;
+  const response = NextResponse.redirect(new URL('/', baseUrl));
+  response.cookies.set('biblioteca-session', defaultUser.id, {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: baseUrl.startsWith('https://'),
+    maxAge: 60 * 60 * 24
+  });
+  return response;
+}

--- a/app/api/dossiers/[id]/export/pdf/route.ts
+++ b/app/api/dossiers/[id]/export/pdf/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function POST(_request: Request, { params }: Props) {
+  return NextResponse.json({ status: 'queued', dossierId: params.id });
+}

--- a/app/api/dossiers/[id]/route.ts
+++ b/app/api/dossiers/[id]/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+import { defaultUser } from '@/data/seeds';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: Props) {
+  const repo = getRepository();
+  const dossiers = await repo.listDossiers(defaultUser.id);
+  const dossier = dossiers.find((item) => item.id === params.id);
+  if (!dossier) {
+    return NextResponse.json({ message: 'No encontrado' }, { status: 404 });
+  }
+  return NextResponse.json(dossier);
+}

--- a/app/api/dossiers/route.ts
+++ b/app/api/dossiers/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+import { defaultUser } from '@/data/seeds';
+
+export async function GET() {
+  const repo = getRepository();
+  const dossiers = await repo.listDossiers(defaultUser.id);
+  return NextResponse.json(dossiers);
+}

--- a/app/api/draft-lens/route.ts
+++ b/app/api/draft-lens/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  if (process.env.AI_ENABLED !== 'true') {
+    return NextResponse.json({ message: 'AI_DISABLED' }, { status: 503 });
+  }
+  return NextResponse.json({ status: 'draft-created' });
+}

--- a/app/api/export/route.ts
+++ b/app/api/export/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import PDFDocument from 'pdfkit';
+import { getRepository } from '@/lib/services/dataService';
+
+export const runtime = 'nodejs';
+
+export async function POST(request: Request) {
+  const { verseRef, lenses } = await request.json();
+  const repo = getRepository();
+  const verse = (await repo.listVerses({})).find((item) => `${item.book} ${item.chapter}:${item.verse}` === verseRef);
+  const interpretations = verse ? await repo.listInterpretations(verse.id) : [];
+  const doc = new PDFDocument();
+  const chunks: Uint8Array[] = [];
+  doc.on('data', (chunk) => chunks.push(chunk));
+  doc.fontSize(18).text('Biblioteca Esotérica – Lentes de Interpretación', { align: 'center' });
+  doc.moveDown();
+  doc.fontSize(14).text(verseRef ?? 'Referencia no proporcionada', { underline: true });
+  doc.moveDown();
+  doc.fontSize(12).text(verse?.text ?? 'Versículo no localizado');
+  doc.moveDown();
+  lenses?.forEach((lensCode: string) => {
+    const lensInterpretations = interpretations.filter((interp) => interp.lens === lensCode);
+    lensInterpretations.forEach((interp) => {
+      doc.fontSize(13).fillColor('#7a1b68').text(`${lensCode.toUpperCase()} (${interp.kind.toUpperCase()})`);
+      doc.fillColor('#111').fontSize(12).text(interp.thesis);
+      doc.fontSize(10).text(interp.bodyMd);
+      doc.moveDown();
+    });
+  });
+  doc.end();
+  const buffer = Buffer.concat(chunks.map((chunk) => Buffer.from(chunk)));
+  const base64 = buffer.toString('base64');
+  const url = `data:application/pdf;base64,${base64}`;
+  return NextResponse.json({ url });
+}

--- a/app/api/lenses/route.ts
+++ b/app/api/lenses/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+export async function GET() {
+  const repo = getRepository();
+  const data = await repo.listLenses();
+  return NextResponse.json(data);
+}

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(request: Request) {
+  const body = await request.json();
+  return NextResponse.json({ status: 'saved', body });
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { searchVerses } from '@/lib/services/search';
+import { incrementSearches } from '@/lib/services/usage';
+import { defaultUser } from '@/data/seeds';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const query = searchParams.get('q') ?? '';
+  try {
+    await incrementSearches(defaultUser.id);
+  } catch (error: any) {
+    if (error.statusCode === 429) {
+      return NextResponse.json(
+        {
+          message: 'Has alcanzado el límite de 3 búsquedas diarias. Intenta mañana.',
+          retryAfterSeconds: error.retryAfter ?? 0
+        },
+        { status: 429 }
+      );
+    }
+    throw error;
+  }
+  const result = await searchVerses({ query }, defaultUser.id);
+  return NextResponse.json(result);
+}

--- a/app/api/symbols/[id]/route.ts
+++ b/app/api/symbols/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: Props) {
+  const repo = getRepository();
+  const symbol = await repo.getSymbolById(params.id);
+  if (!symbol) {
+    return NextResponse.json({ message: 'No encontrado' }, { status: 404 });
+  }
+  return NextResponse.json(symbol);
+}

--- a/app/api/symbols/route.ts
+++ b/app/api/symbols/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+export async function GET() {
+  const repo = getRepository();
+  const symbols = await repo.listSymbols();
+  return NextResponse.json(symbols);
+}

--- a/app/api/usage/increment/route.ts
+++ b/app/api/usage/increment/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { incrementSearches } from '@/lib/services/usage';
+import { defaultUser } from '@/data/seeds';
+
+export async function POST() {
+  try {
+    const usage = await incrementSearches(defaultUser.id);
+    return NextResponse.json(usage);
+  } catch (error: any) {
+    if (error.statusCode === 429) {
+      return NextResponse.json({ message: 'Límite alcanzado' }, { status: 429 });
+    }
+    throw error;
+  }
+}

--- a/app/api/usage/route.ts
+++ b/app/api/usage/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { remainingSearches } from '@/lib/services/usage';
+import { defaultUser } from '@/data/seeds';
+
+export async function GET() {
+  const usage = await remainingSearches(defaultUser.id);
+  return NextResponse.json(usage);
+}

--- a/app/api/verses/[id]/interpretations/route.ts
+++ b/app/api/verses/[id]/interpretations/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: Props) {
+  const body = await request.json();
+  return NextResponse.json({ status: 'received', verseId: params.id, body });
+}

--- a/app/api/verses/[id]/lenses/route.ts
+++ b/app/api/verses/[id]/lenses/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: Props) {
+  const repo = getRepository();
+  const interpretations = await repo.listInterpretations(params.id);
+  return NextResponse.json(interpretations);
+}

--- a/app/api/verses/[id]/route.ts
+++ b/app/api/verses/[id]/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+interface Props {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: Props) {
+  const repo = getRepository();
+  const verse = await repo.getVerseById(params.id);
+  if (!verse) {
+    return NextResponse.json({ message: 'No encontrado' }, { status: 404 });
+  }
+  return NextResponse.json(verse);
+}

--- a/app/api/verses/route.ts
+++ b/app/api/verses/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+import { getRepository } from '@/lib/services/dataService';
+
+export async function GET(request: Request) {
+  const repo = getRepository();
+  const { searchParams } = new URL(request.url);
+  const version = searchParams.get('version') ?? undefined;
+  const book = searchParams.get('book') ?? undefined;
+  const chapter = searchParams.get('chapter');
+  const verses = await repo.listVerses({ versionId: version, book: book ?? undefined, chapter: chapter ? Number(chapter) : undefined });
+  return NextResponse.json(verses);
+}

--- a/app/cuaderno/page.tsx
+++ b/app/cuaderno/page.tsx
@@ -1,0 +1,22 @@
+import { CuadernoPanel } from '@/components/CuadernoPanel';
+import { getRepository } from '@/lib/services/dataService';
+import { defaultUser } from '@/data/seeds';
+
+export default async function CuadernoPage() {
+  const repo = getRepository();
+  const notes = await repo.listNotes(defaultUser.id);
+  const dossiers = await repo.listDossiers(defaultUser.id);
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-2xl font-semibold text-amber-800">Cuaderno del investigador</h1>
+        <p className="text-sm text-slate-600">
+          Consolida subrayados, notas temáticas y dossiers exportables a PDF. Cada entrada conserva la referencia y la lente
+          asociada para trazabilidad Dato/Tradición.
+        </p>
+      </header>
+      <CuadernoPanel notes={notes} dossiers={dossiers} />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,63 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #fdf7ef;
+  color: #2f1f0e;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}
+
+.bg-sand {
+  background: #fdf7ef;
+}
+
+.card {
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  background: #fff;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.03);
+}
+
+.badge-dato {
+  background: #0c5d3d;
+  color: white;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.badge-tradicion {
+  background: #7a1b68;
+  color: white;
+  border-radius: 999px;
+  padding: 0.2rem 0.75rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+}
+
+.progress-container {
+  height: 6px;
+  width: 100%;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+}
+
+.progress-bar {
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, #ffd700, #ff9800);
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,38 @@
+import type { Metadata } from 'next';
+import './globals.css';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+  title: 'Biblioteca Esotérica – Lentes de Interpretación',
+  description:
+    'Plataforma de investigación bíblica con lentes de interpretación literal, histórico-crítica, alegórica-tipológica, moral, esotérica y sod.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="es">
+      <body className="min-h-screen bg-sand text-slate-900">
+        <header className="border-b border-amber-200 bg-white/70 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+          <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-4">
+            <Link href="/" className="font-semibold tracking-tight text-amber-700">
+              Biblioteca Esotérica
+            </Link>
+            <nav className="flex items-center gap-4 text-sm">
+              <Link href="/leer">Leer</Link>
+              <Link href="/cuaderno">Cuaderno</Link>
+              <Link href="/login">Acceso</Link>
+            </nav>
+          </div>
+        </header>
+        <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
+        <footer className="border-t border-amber-200 bg-white/70 text-xs text-slate-500">
+          <div className="mx-auto max-w-6xl px-4 py-4 flex flex-wrap gap-4">
+            <span>AI_ENABLED: {process.env.AI_ENABLED ?? 'false'}</span>
+            <span>PAYMENTS_ENABLED: {process.env.PAYMENTS_ENABLED ?? 'false'}</span>
+            <span>Límite diario: 3 búsquedas</span>
+          </div>
+        </footer>
+      </body>
+    </html>
+  );
+}

--- a/app/leer/page.tsx
+++ b/app/leer/page.tsx
@@ -1,0 +1,28 @@
+import { VerseSelector } from '@/components/VerseSelector';
+import { getRepository } from '@/lib/services/dataService';
+
+export default async function LeerPage() {
+  const repo = getRepository();
+  const verses = await repo.listVerses({});
+  const versions = await repo.listVersions();
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold text-amber-800">Navegación canónica</h1>
+        <p className="text-sm text-slate-600">
+          Selecciona versión, libro y capítulo para explorar los versículos disponibles. Actualmente cargada la RVR1909 con Juan 3
+          y Números 21.
+        </p>
+        <div className="flex flex-wrap gap-3 text-sm">
+          {versions.map((version) => (
+            <span key={version.id} className="rounded-full border border-amber-200 px-3 py-1">
+              {version.name} ({version.year})
+            </span>
+          ))}
+        </div>
+      </header>
+      <VerseSelector verses={verses} />
+    </div>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function LoginPage() {
+  return (
+    <div className="mx-auto max-w-md space-y-6 text-center">
+      <h1 className="text-2xl font-semibold text-amber-800">Acceso a la Biblioteca</h1>
+      <p className="text-sm text-slate-600">
+        El ingreso se realiza exclusivamente con Google (OAuth2: openid email profile). En esta fase el servicio es gratuito, pero
+        ya está preparado para habilitar pagos en el futuro.
+      </p>
+      <form action="/api/auth/login-google" method="get">
+        <button className="w-full rounded-full bg-amber-700 px-5 py-3 font-semibold text-white" type="submit">
+          Acceder con Google
+        </button>
+      </form>
+      <p className="text-xs text-slate-500">
+        Al continuar aceptas la política de privacidad y el límite de 3 búsquedas diarias. <Link href="/">Volver al inicio</Link>.
+      </p>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,27 @@
+import { SearchBar } from '@/components/SearchBar';
+import { UsageNotice } from '@/components/UsageNotice';
+import { GlosarioList } from '@/components/GlosarioList';
+import { getRepository } from '@/lib/services/dataService';
+import { remainingSearches } from '@/lib/services/usage';
+import { defaultUser } from '@/data/seeds';
+
+export default async function HomePage() {
+  const repo = getRepository();
+  const symbols = await repo.listSymbols();
+  const usage = await remainingSearches(defaultUser.id);
+
+  return (
+    <div className="space-y-8">
+      <UsageNotice remaining={usage.remaining} resetAt={usage.resetAt.toISOString()} />
+      <SearchBar remainingSearches={usage.remaining} />
+      <section>
+        <h2 className="text-xl font-semibold text-amber-800">Facetas destacadas</h2>
+        <p className="text-sm text-slate-600">
+          Filtra por referencia, tema, símbolo, número Strong, lente o tipo (Dato/Tradición). Operadores permitidos: AND implícito,
+          OR, NOT (prefijo -) y comillas para frases exactas.
+        </p>
+      </section>
+      <GlosarioList symbols={symbols} />
+    </div>
+  );
+}

--- a/app/versiculo/[...refParts]/page.tsx
+++ b/app/versiculo/[...refParts]/page.tsx
@@ -1,0 +1,51 @@
+import { LensTabs } from '@/components/LensTabs';
+import { ExportButton } from '@/components/ExportButton';
+import { getRepository } from '@/lib/services/dataService';
+import { bookToSlug } from '@/lib/utils/bookSlug';
+
+interface PageProps {
+  params: {
+    refParts: string[];
+  };
+}
+
+export default async function VersePage({ params }: PageProps) {
+  const repo = getRepository();
+  const allVerses = await repo.listVerses({});
+  const bookRegistry = new Map(allVerses.map((verse) => [bookToSlug(verse.book), verse.book]));
+  const [bookParam, chapterParam, verseParam] = params.refParts ?? [];
+  const book = bookRegistry.get(bookToSlug(bookParam ?? '')) ?? 'Juan';
+  const chapter = Number(chapterParam ?? 3);
+  const verseNumber = Number(verseParam ?? 14);
+  const verses = allVerses.filter((item) => item.book === book && item.chapter === chapter);
+  const verse = verses.find((item) => item.verse === verseNumber);
+  if (!verse) {
+    return <div className="text-sm text-red-600">Versículo no encontrado.</div>;
+  }
+  const lenses = await repo.listLenses();
+  const interpretations = await repo.listInterpretations(verse.id);
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <p className="text-sm uppercase tracking-widest text-slate-500">Texto base</p>
+        <h1 className="text-3xl font-semibold text-amber-800">
+          {verse.book} {verse.chapter}:{verse.verse}
+        </h1>
+        <p className="text-lg text-slate-700">{verse.text}</p>
+        <div className="text-sm text-slate-500">Versión: RVR1909 · Interlineal básico disponible</div>
+      </header>
+      <section className="grid gap-4 rounded-2xl border border-amber-100 bg-white/70 p-4 text-sm text-slate-600">
+        <h2 className="text-xl font-semibold text-amber-800">Interlineal</h2>
+        <p>
+          Lemma clave: <strong>ὑψωθῆναι (hypsōthēnai)</strong> — Glosa: “ser levantado / exaltado”. Strong: G5312. Morfología: aoristo infinitivo pasivo.
+        </p>
+        <p>
+          Hebreo de referencia: <strong>נְחַשׁ (najásh)</strong> Strong H5175. Campo semántico: serpiente, bronce, hechicero.
+        </p>
+      </section>
+      <LensTabs interpretations={interpretations} lenses={lenses} />
+      <ExportButton verseRef={`${verse.book} ${verse.chapter}:${verse.verse}`} lenses={lenses.map((lens) => lens.code)} />
+    </div>
+  );
+}

--- a/components/CuadernoPanel.tsx
+++ b/components/CuadernoPanel.tsx
@@ -1,0 +1,46 @@
+import { Dossier, Note } from '@/lib/types';
+
+interface Props {
+  notes: Note[];
+  dossiers: Dossier[];
+}
+
+export function CuadernoPanel({ notes, dossiers }: Props) {
+  return (
+    <div className="grid gap-6 md:grid-cols-2">
+      <section className="card">
+        <h3 className="text-lg font-semibold text-amber-800">Subrayados y notas</h3>
+        <ul className="mt-4 space-y-3">
+          {notes.map((note) => (
+            <li key={note.id} className="rounded-lg border border-amber-100 bg-white px-3 py-2">
+              <div className="text-xs uppercase text-slate-500">{note.createdAt.slice(0, 10)}</div>
+              <p className="text-sm text-slate-700">{note.content}</p>
+              <div className="mt-2 flex flex-wrap gap-2 text-xs text-amber-700">
+                {note.tags.map((tag) => (
+                  <span key={tag} className="rounded-full border border-amber-200 px-2 py-0.5">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="card">
+        <h3 className="text-lg font-semibold text-amber-800">Dossiers</h3>
+        <ul className="mt-4 space-y-3">
+          {dossiers.map((dossier) => (
+            <li key={dossier.id} className="rounded-lg border border-amber-100 bg-white px-3 py-2">
+              <div className="text-xs uppercase text-slate-500">{dossier.createdAt.slice(0, 10)}</div>
+              <p className="text-base font-semibold text-slate-800">{dossier.title}</p>
+              <p className="text-sm text-slate-600">{dossier.bodyMd}</p>
+              <button className="mt-3 text-sm text-amber-700 underline" type="button" onClick={() => alert('Exportación PDF pendiente en server')}>
+                Exportar a PDF
+              </button>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/components/ExportButton.tsx
+++ b/components/ExportButton.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+interface Props {
+  verseRef: string;
+  lenses: string[];
+}
+
+export function ExportButton({ verseRef, lenses }: Props) {
+  const [message, setMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleExport = async () => {
+    setIsLoading(true);
+    setMessage('');
+    try {
+      const response = await fetch('/api/export', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ verseRef, lenses })
+      });
+      if (!response.ok) {
+        throw new Error('No fue posible exportar.');
+      }
+      const payload = await response.json();
+      setMessage(`PDF generado: ${payload.url}`);
+    } catch (error: any) {
+      setMessage(error.message);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <button
+        type="button"
+        className="rounded-full bg-amber-700 px-4 py-2 text-sm font-semibold text-white disabled:bg-amber-200"
+        onClick={handleExport}
+        disabled={isLoading}
+      >
+        {isLoading ? 'Generando PDF…' : 'Exportar versículo + lentes'}
+      </button>
+      {message && <p className="text-xs text-slate-500">{message}</p>}
+    </div>
+  );
+}

--- a/components/GlosarioList.tsx
+++ b/components/GlosarioList.tsx
@@ -1,0 +1,25 @@
+import { SymbolEntry } from '@/lib/types';
+
+interface Props {
+  symbols: SymbolEntry[];
+}
+
+export function GlosarioList({ symbols }: Props) {
+  return (
+    <div className="card">
+      <h3 className="text-lg font-semibold text-amber-800">Glosario y correspondencias</h3>
+      <ul className="mt-4 space-y-3">
+        {symbols.map((symbol) => (
+          <li key={symbol.id} className="rounded-lg border border-amber-100 bg-white px-3 py-2">
+            <div className="flex items-center justify-between">
+              <strong>{symbol.name}</strong>
+              {symbol.isTradition && <span className="badge-tradicion">Tradición</span>}
+            </div>
+            <p className="text-sm text-slate-600">{symbol.definition}</p>
+            <div className="mt-2 text-xs text-slate-500">Aparece en: {symbol.appearsIn.join(', ')}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/LensCard.tsx
+++ b/components/LensCard.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { Interpretation } from '@/lib/types';
+
+interface Props {
+  interpretation: Interpretation;
+}
+
+export function LensCard({ interpretation }: Props) {
+  const badgeClass = interpretation.kind === 'dato' ? 'badge-dato' : 'badge-tradicion';
+  const label = interpretation.kind === 'dato' ? 'Dato' : 'Tradición';
+  return (
+    <article className="card">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-widest text-slate-500">Tesis</div>
+          <p className="font-semibold text-lg text-amber-800">{interpretation.thesis}</p>
+        </div>
+        <span className={badgeClass}>{label}</span>
+      </header>
+      <p className="mt-4 text-sm leading-relaxed text-slate-700">{interpretation.bodyMd}</p>
+      <div className="mt-4 flex flex-wrap items-center gap-3 text-xs uppercase tracking-wide text-slate-500">
+        <span>Confianza</span>
+        <div className="progress-container">
+          <div className="progress-bar" style={{ width: `${Math.round(interpretation.confidence * 100)}%` }} />
+        </div>
+        <span>{(interpretation.confidence * 100).toFixed(0)}%</span>
+      </div>
+      <div className="mt-4 text-sm">
+        <button className="text-amber-700 underline" type="button" onClick={() => alert(interpretation.sources.join(', '))}>
+          Ver fuentes
+        </button>
+      </div>
+      <ul className="mt-2 text-xs text-slate-500">
+        {interpretation.citations.map((citation) => (
+          <li key={citation}>• {citation}</li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/components/LensTabs.tsx
+++ b/components/LensTabs.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useState } from 'react';
+import { Interpretation, LensMeta } from '@/lib/types';
+import { LensCard } from '@/components/LensCard';
+
+interface Props {
+  interpretations: Interpretation[];
+  lenses: LensMeta[];
+}
+
+export function LensTabs({ interpretations, lenses }: Props) {
+  const [activeLens, setActiveLens] = useState(lenses[0]?.code ?? 'literal');
+  const activeInterpretations = interpretations.filter((item) => item.lens === activeLens);
+
+  return (
+    <section>
+      <div className="flex flex-wrap gap-3">
+        {lenses.map((lens) => (
+          <button
+            key={lens.code}
+            className={`rounded-full border px-4 py-2 text-sm ${
+              activeLens === lens.code ? 'border-amber-700 bg-amber-700 text-white' : 'border-amber-200 bg-white'
+            }`}
+            onClick={() => setActiveLens(lens.code)}
+          >
+            {lens.name}
+          </button>
+        ))}
+      </div>
+      <div className="mt-6 grid gap-4">
+        {activeInterpretations.length === 0 && (
+          <div className="rounded-xl border border-dashed border-amber-300 p-6 text-sm text-slate-500">
+            No concluyente: no hay interpretaciones publicadas para este lente.
+          </div>
+        )}
+        {activeInterpretations.map((interpretation) => (
+          <LensCard key={interpretation.id} interpretation={interpretation} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { bookToSlug } from '@/lib/utils/bookSlug';
+
+interface Props {
+  defaultQuery?: string;
+  remainingSearches: number;
+}
+
+export function SearchBar({ defaultQuery = '', remainingSearches }: Props) {
+  const [query, setQuery] = useState(defaultQuery);
+  const [isSearching, setIsSearching] = useState(false);
+  const [results, setResults] = useState<any[]>([]);
+  const [facets, setFacets] = useState<Record<string, Record<string, number>>>({});
+  const [remaining, setRemaining] = useState(remainingSearches);
+  const [message, setMessage] = useState('');
+
+  const handleSearch = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!query.trim() || remaining <= 0) return;
+    setIsSearching(true);
+    setMessage('');
+    try {
+      const response = await fetch(`/api/search?q=${encodeURIComponent(query)}`);
+      if (response.status === 429) {
+        const payload = await response.json();
+        setMessage(payload.message);
+        setRemaining(0);
+        return;
+      }
+      const payload = await response.json();
+      setResults(payload.results);
+      setFacets(payload.facets);
+      setRemaining(payload.remainingSearches);
+    } catch (error) {
+      setMessage('Error al buscar.');
+    } finally {
+      setIsSearching(false);
+    }
+  };
+
+  return (
+    <div className="card">
+      <form className="flex flex-col gap-3" onSubmit={handleSearch}>
+        <label className="text-sm font-semibold uppercase tracking-widest text-amber-700">Buscador global</label>
+        <input
+          className="rounded-xl border border-amber-200 bg-white px-4 py-3 text-base shadow-sm"
+          placeholder='Ej. "serpiente de bronce" OR strong:H5175 libro:Juan'
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          disabled={remaining <= 0}
+        />
+        <div className="flex flex-wrap items-center gap-4 text-sm">
+          <button
+            type="submit"
+            className="rounded-full bg-amber-700 px-5 py-2 font-semibold text-white disabled:cursor-not-allowed disabled:bg-amber-200"
+            disabled={isSearching || remaining <= 0}
+          >
+            Buscar
+          </button>
+          <span>Búsquedas restantes hoy: {remaining}</span>
+          {message && <span className="text-red-600">{message}</span>}
+        </div>
+      </form>
+      {results.length > 0 && (
+        <div className="mt-6 grid gap-3">
+          {results.map((verse) => (
+            <article key={verse.id} className="rounded-xl border border-amber-100 bg-white p-4 shadow-sm">
+              <a href={`/versiculo/${bookToSlug(verse.book)}/${verse.chapter}/${verse.verse}`} className="font-semibold">
+                {verse.book} {verse.chapter}:{verse.verse}
+              </a>
+              <p className="mt-2 text-sm leading-relaxed text-slate-700">{verse.text}</p>
+            </article>
+          ))}
+        </div>
+      )}
+      {Object.keys(facets).length > 0 && (
+        <div className="mt-6 grid grid-cols-1 gap-4 md:grid-cols-3">
+          {Object.entries(facets).map(([facet, values]) => (
+            <div key={facet} className="rounded-lg border border-amber-100 bg-white p-3 text-sm">
+              <strong className="uppercase text-amber-700">{facet}</strong>
+              <ul className="mt-2 space-y-1">
+                {Object.entries(values).map(([label, count]) => (
+                  <li key={label} className="flex justify-between">
+                    <span>{label}</span>
+                    <span>{count}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/UsageNotice.tsx
+++ b/components/UsageNotice.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  remaining: number;
+  resetAt: string;
+}
+
+export function UsageNotice({ remaining, resetAt }: Props) {
+  return (
+    <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+      <strong>{remaining}</strong> búsquedas disponibles hoy. Se reinicia a las {new Date(resetAt).toLocaleTimeString('es-ES')} UTC.
+    </div>
+  );
+}

--- a/components/VerseSelector.tsx
+++ b/components/VerseSelector.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Verse } from '@/lib/types';
+import { useMemo, useState } from 'react';
+import { bookToSlug } from '@/lib/utils/bookSlug';
+
+interface Props {
+  verses: Verse[];
+}
+
+export function VerseSelector({ verses }: Props) {
+  const books = Array.from(new Set(verses.map((verse) => verse.book)));
+  const [book, setBook] = useState(books[0] ?? 'Juan');
+  const chapters = useMemo(
+    () => Array.from(new Set(verses.filter((verse) => verse.book === book).map((verse) => verse.chapter))).sort((a, b) => a - b),
+    [book, verses]
+  );
+  const [chapter, setChapter] = useState(chapters[0] ?? 1);
+  const availableVerses = verses.filter((verse) => verse.book === book && verse.chapter === chapter);
+
+  return (
+    <div className="card space-y-4">
+      <div>
+        <label className="text-xs uppercase text-slate-500">Libro</label>
+        <select className="w-full rounded-xl border border-amber-200 px-3 py-2" value={book} onChange={(event) => setBook(event.target.value)}>
+          {books.map((option) => (
+            <option key={option}>{option}</option>
+          ))}
+        </select>
+      </div>
+      <div>
+        <label className="text-xs uppercase text-slate-500">Capítulo</label>
+        <select className="w-full rounded-xl border border-amber-200 px-3 py-2" value={chapter} onChange={(event) => setChapter(Number(event.target.value))}>
+          {chapters.map((option) => (
+            <option key={option}>{option}</option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-2">
+        {availableVerses.map((verse) => (
+          <a key={verse.id} href={`/versiculo/${bookToSlug(verse.book)}/${verse.chapter}/${verse.verse}`} className="block rounded-lg border border-amber-100 bg-white px-3 py-2">
+            {verse.book} {verse.chapter}:{verse.verse} — {verse.text}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/data/seeds.ts
+++ b/data/seeds.ts
@@ -1,0 +1,280 @@
+import { Dossier, Interpretation, LensMeta, Note, SymbolEntry, UsageRecord, User, Verse, Version } from '@/lib/types';
+
+export const defaultUser: User = {
+  id: 'user-demo',
+  email: 'demo@biblioteca.es',
+  name: 'Investigador Demo',
+  avatarUrl: 'https://example.com/avatar.png',
+  createdAt: new Date('2024-01-01').toISOString()
+};
+
+export const versions: Version[] = [
+  {
+    id: 'rvr1909',
+    code: 'RVR1909',
+    name: 'Reina-Valera 1909',
+    lang: 'es',
+    year: 1909,
+    license: 'Dominio público'
+  }
+];
+
+export const verses: Verse[] = [
+  {
+    id: 'jn-3-14',
+    versionId: 'rvr1909',
+    book: 'Juan',
+    chapter: 3,
+    verse: 14,
+    text: 'Y como Moisés levantó la serpiente en el desierto, así es necesario que el Hijo del hombre sea levantado;'
+  },
+  {
+    id: 'jn-3-15',
+    versionId: 'rvr1909',
+    book: 'Juan',
+    chapter: 3,
+    verse: 15,
+    text: 'Para que todo aquel que en él cree, no se pierda, mas tenga vida eterna.'
+  },
+  {
+    id: 'num-21-8',
+    versionId: 'rvr1909',
+    book: 'Números',
+    chapter: 21,
+    verse: 8,
+    text: 'Y Jehová dijo a Moisés: Hazte una serpiente ardiente, y ponla sobre un asta; y será, que cualquiera que fuere mordido, y mirare a ella, vivirá.'
+  },
+  {
+    id: 'num-21-9',
+    versionId: 'rvr1909',
+    book: 'Números',
+    chapter: 21,
+    verse: 9,
+    text: 'Y Moisés hizo una serpiente de metal, y púsola sobre un asta; y fué, que cuando alguna serpiente mordía a alguno, miraba a la serpiente de metal, y vivía.'
+  }
+];
+
+export const lenses: LensMeta[] = [
+  { code: 'literal', name: 'Literal', description: 'Lectura directa del texto', isTradition: false },
+  { code: 'historico_critica', name: 'Histórico-crítica', description: 'Contexto histórico y textual', isTradition: false },
+  { code: 'alegorica_tipologica', name: 'Alegórica-tipológica', description: 'Correspondencias simbólicas clásicas', isTradition: true },
+  { code: 'moral', name: 'Moral', description: 'Aplicación ética', isTradition: true },
+  { code: 'esoterica', name: 'Esotérica', description: 'Lectura simbólica interna', isTradition: true },
+  { code: 'sod', name: 'Sod', description: 'Dimensión sod (misterio)', isTradition: true }
+];
+
+export const symbols: SymbolEntry[] = [
+  {
+    id: 'symbol-serpiente',
+    name: 'Serpiente',
+    type: 'animal',
+    definition: 'Figura ambivalente: juicio y sanidad cuando es elevada.',
+    sources: ['Glosario interno'],
+    appearsIn: ['Números 21:8-9', 'Juan 3:14'],
+    isTradition: true
+  },
+  {
+    id: 'symbol-bronce',
+    name: 'Bronce',
+    type: 'metal',
+    definition: 'Metal asociado a juicio purificador y resistencia.',
+    sources: ['Glosario interno'],
+    appearsIn: ['Números 21:9'],
+    isTradition: true
+  },
+  {
+    id: 'symbol-desierto',
+    name: 'Desierto',
+    type: 'lugar',
+    definition: 'Ámbito de prueba y pedagogía divina.',
+    sources: ['Glosario interno'],
+    appearsIn: ['Números 21', 'Juan 3'],
+    isTradition: true
+  },
+  {
+    id: 'symbol-cuarenta',
+    name: 'Cuarenta',
+    type: 'numero',
+    definition: 'Tiempo completo de purificación y tránsito.',
+    sources: ['Glosario interno'],
+    appearsIn: ['Éxodo', 'Números'],
+    isTradition: true
+  }
+];
+
+export const interpretations: Interpretation[] = [
+  {
+    id: 'jn-3-14-literal',
+    verseId: 'jn-3-14',
+    lens: 'literal',
+    thesis: 'Jesús equipara su elevación con el signo de Moisés.',
+    bodyMd:
+      'El texto afirma que, así como Moisés levantó la serpiente en el desierto (Núm 21:8-9), el Hijo del Hombre debe ser levantado. La estructura compara dos eventos históricos concretos y prepara el argumento de salvación en los versículos siguientes. Se destaca la necesidad (“es necesario”) de la exaltación para que la comunidad comprenda la misión de Jesús.',
+    citations: ['Números 21:8-9', 'Juan 3:14-15'],
+    sources: ['RVR1909'],
+    kind: 'dato',
+    confidence: 0.92,
+    status: 'published'
+  },
+  {
+    id: 'jn-3-14-hist',
+    verseId: 'jn-3-14',
+    lens: 'historico_critica',
+    thesis: 'El signo de la serpiente refleja una tradición de curación mediada.',
+    bodyMd:
+      'El evangelio de Juan recurre a la narrativa de Números, reconocible en el judaísmo del siglo I, para situar la crucifixión como gesto divino de sanación comunitaria. El verbo “levantado” dialoga con la exaltación y con el lenguaje de Isaías 52:13, indicando que la comunidad joánica relee la Pascua desde el desierto. La memoria de las plagas y la mediación mosaica sostiene la interpretación.',
+    citations: ['Números 21:8-9', 'Isaías 52:13', 'Juan 3:14'],
+    sources: ['RVR1909', 'Notas históricas internas'],
+    kind: 'dato',
+    confidence: 0.88,
+    status: 'published'
+  },
+  {
+    id: 'jn-3-14-aleg',
+    verseId: 'jn-3-14',
+    lens: 'alegorica_tipologica',
+    thesis: 'La serpiente elevada figura la cruz que transmuta el veneno en medicina.',
+    bodyMd:
+      'La imagen mosaica convierte el instrumento de juicio en canal de vida. La cruz recoge ese giro y lo expande: el Cristo elevado absorbe el veneno del mundo, como la serpiente de bronce concentró las mordeduras del campamento. Así, el signo del desierto se vuelve tipo profético que orienta a Nicodemo hacia el nuevo nacimiento. La mirada de fe es el acto alquímico que transmuta muerte en vida.',
+    citations: ['Números 21:8-9', 'Juan 3:14-15', 'Sabiduría 16:5-7'],
+    sources: ['Glosario interno', 'RVR1909'],
+    kind: 'tradicion',
+    confidence: 0.78,
+    status: 'published'
+  },
+  {
+    id: 'jn-3-14-moral',
+    verseId: 'jn-3-14',
+    lens: 'moral',
+    thesis: 'La elevación llama a confrontar el mal mirándolo de frente.',
+    bodyMd:
+      'Así como Israel debía fijar los ojos en la serpiente para asumir su responsabilidad colectiva, el discípulo enfrenta el pecado reconociéndolo ante la cruz. La obediencia de mirar determina la sanación; la actitud negligente prolonga el daño. La lectura moral resalta la disciplina de la mirada purificada y la solidaridad con quienes sufren mordeduras en el camino.',
+    citations: ['Números 21:8-9', 'Juan 3:14-15'],
+    sources: ['RVR1909', 'Tradición catequética'],
+    kind: 'tradicion',
+    confidence: 0.74,
+    status: 'published'
+  },
+  {
+    id: 'jn-3-14-esot',
+    verseId: 'jn-3-14',
+    lens: 'esoterica',
+    thesis: 'El ascenso del Hijo del Hombre abre el canal axial entre cielo y tierra.',
+    bodyMd:
+      'La serpiente elevada representa la columna de energía que recorre al pueblo y lo recentra en el Nombre. Cuando el Cristo es levantado, el eje se instala en el corazón humano y neutraliza el veneno de la dualidad. El metal ardiente condensa el fuego kundalínico del desierto, que al elevarse concede visión interior. La mirada se transforma en contemplación y el veneno se transmuta en sabiduría.',
+    citations: ['Números 21:8-9', 'Juan 3:14', 'Juan 12:32'],
+    sources: ['Glosario esotérico interno'],
+    kind: 'tradicion',
+    confidence: 0.66,
+    status: 'published'
+  },
+  {
+    id: 'jn-3-14-sod',
+    verseId: 'jn-3-14',
+    lens: 'sod',
+    thesis: 'El misterio sod revela que el veneno deviene antídoto al ser elevado.',
+    bodyMd:
+      'En clave sod, la serpiente es la energía serpentina que custodia el umbral del conocimiento. Al elevarla, Moisés anticipa el secreto de la cruz: el Logos asume el veneno y lo fija en la luz. El nombre “Hijo del Hombre” cifra la humanidad universal, de modo que al ser levantado, toda carne queda magnetizada. Las citas de Números y Juan componen un quiasmo que señala la inversión del juicio.',
+    citations: ['Números 21:8-9', 'Juan 3:14', 'Juan 3:15'],
+    sources: ['Cuaderno sod'],
+    kind: 'tradicion',
+    confidence: 0.71,
+    status: 'published'
+  },
+  {
+    id: 'num-21-8-literal',
+    verseId: 'num-21-8',
+    lens: 'literal',
+    thesis: 'YHWH instruye a Moisés a fabricar un signo de bronce para sanar.',
+    bodyMd:
+      'El versículo describe un mandato concreto: fabricar una serpiente ardiente y colocarla sobre un asta. La promesa es funcional: quien haya sido mordido y mire el signo, vivirá. El texto delimita al sujeto (Moisés), la acción (hacer y elevar) y la consecuencia (sanidad), sin añadir capas simbólicas.',
+    citations: ['Números 21:8', 'Números 21:9'],
+    sources: ['RVR1909'],
+    kind: 'dato',
+    confidence: 0.93,
+    status: 'published'
+  },
+  {
+    id: 'num-21-8-hist',
+    verseId: 'num-21-8',
+    lens: 'historico_critica',
+    thesis: 'El signo proviene de tradiciones del desierto tardío.',
+    bodyMd:
+      'El pasaje refleja prácticas de talismanes metálicos comunes en el Cercano Oriente. El redactor sacerdotal legitima el objeto al atribuirlo al mandato divino y al liderazgo de Moisés. El relato funcionó para explicar un objeto de culto (nehushtán) que siglos después sería destruido (2 Reyes 18:4).',
+    citations: ['Números 21:8-9', '2 Reyes 18:4'],
+    sources: ['RVR1909', 'Crítica textual interna'],
+    kind: 'dato',
+    confidence: 0.81,
+    status: 'published'
+  },
+  {
+    id: 'num-21-8-aleg',
+    verseId: 'num-21-8',
+    lens: 'alegorica_tipologica',
+    thesis: 'El asta anticipa la cruz que se levanta en el desierto interior.',
+    bodyMd:
+      'El pueblo atraviesa un desierto físico y existencial; la serpiente ardiente reúne juicio y medicina. Al mirarla, Israel reconoce su falla y recibe vida. Esta dinámica se convierte en figura de la cruz, en la cual el signo mortal es girado en remedio. La vara vertical se vuelve eje que conecta tierra y cielo.',
+    citations: ['Números 21:8-9', 'Juan 3:14'],
+    sources: ['Glosario tipológico'],
+    kind: 'tradicion',
+    confidence: 0.69,
+    status: 'published'
+  },
+  {
+    id: 'num-21-8-esot',
+    verseId: 'num-21-8',
+    lens: 'esoterica',
+    thesis: 'La serpiente ardiente condensa el fuego kundalini que eleva a la asamblea.',
+    bodyMd:
+      'El metal incandescente simboliza la energía serpentina que asciende por la columna del peregrino. Al ser fijada en el asta, la fuerza dispersa se alinea y devuelve equilibrio al campamento. Mirar el signo implica activar la visión interior que transmuta el veneno en luz. El rito apunta a despertar colectivo.',
+    citations: ['Números 21:8-9', 'Sabiduría 16:5-7'],
+    sources: ['Glosario esotérico'],
+    kind: 'tradicion',
+    confidence: 0.65,
+    status: 'published'
+  },
+  {
+    id: 'num-21-8-sod',
+    verseId: 'num-21-8',
+    lens: 'sod',
+    thesis: 'El nehushtán guarda el secreto de invertir la polaridad del veneno.',
+    bodyMd:
+      'Al combinar cobre (nechosheth) con el verbo “besar” del asta, el relato sugiere un sello místico: el veneno se vuelve antídoto cuando se fija en la letra vav (el asta). El acto de mirar introduce al iniciado en la corriente sod, donde la muerte es absorbida por el Nombre. El versículo conserva la fórmula de inversión.',
+    citations: ['Números 21:8-9', 'Juan 3:14'],
+    sources: ['Cuaderno sod'],
+    kind: 'tradicion',
+    confidence: 0.7,
+    status: 'published'
+  }
+];
+
+export const notes: Note[] = [
+  {
+    id: 'note-1',
+    userId: defaultUser.id,
+    verseId: 'jn-3-14',
+    content: 'Explorar paralelos con Sabiduría 16 y los rollos del Mar Muerto.',
+    tags: ['investigación', 'sabiduria'],
+    createdAt: new Date('2024-02-10').toISOString()
+  }
+];
+
+export const dossiers: Dossier[] = [
+  {
+    id: 'dossier-1',
+    userId: defaultUser.id,
+    title: 'Paralelos de la serpiente de bronce',
+    bodyMd: 'Recopilación de lentes y correspondencias sobre Números 21 y Juan 3.',
+    references: ['Números 21:8-9', 'Juan 3:14-15'],
+    createdAt: new Date('2024-03-01').toISOString()
+  }
+];
+
+export const usageRecords: UsageRecord[] = [
+  {
+    id: 'usage-1',
+    userId: defaultUser.id,
+    date: new Date().toISOString().split('T')[0],
+    searches: 0
+  }
+];

--- a/lib/adapters/inMemoryAdapter.ts
+++ b/lib/adapters/inMemoryAdapter.ts
@@ -1,0 +1,86 @@
+import {
+  defaultUser,
+  dossiers,
+  interpretations,
+  lenses,
+  notes,
+  symbols,
+  usageRecords,
+  verses,
+  versions
+} from '@/data/seeds';
+import { Repository } from '@/lib/repositories/base';
+import { Dossier, Interpretation, LensMeta, Note, SymbolEntry, UsageRecord, User, Verse, Version } from '@/lib/types';
+
+const usageMap = new Map<string, UsageRecord>();
+usageRecords.forEach((record) => usageMap.set(`${record.userId}-${record.date}`, record));
+
+export class InMemoryAdapter implements Repository {
+  async getUserById(id: string): Promise<User | null> {
+    return id === defaultUser.id ? defaultUser : null;
+  }
+
+  async getOrCreateUsage(userId: string, date: string): Promise<UsageRecord> {
+    const key = `${userId}-${date}`;
+    if (!usageMap.has(key)) {
+      const record: UsageRecord = {
+        id: `usage-${usageMap.size + 1}`,
+        userId,
+        date,
+        searches: 0
+      };
+      usageMap.set(key, record);
+    }
+    return usageMap.get(key)!;
+  }
+
+  async incrementUsage(userId: string, date: string): Promise<UsageRecord> {
+    const record = await this.getOrCreateUsage(userId, date);
+    record.searches += 1;
+    usageMap.set(`${userId}-${date}`, record);
+    return record;
+  }
+
+  async listVersions(): Promise<Version[]> {
+    return versions;
+  }
+
+  async listVerses(params: { versionId?: string; book?: string; chapter?: number }): Promise<Verse[]> {
+    return verses.filter((verse) => {
+      if (params.versionId && verse.versionId !== params.versionId) return false;
+      if (params.book && verse.book !== params.book) return false;
+      if (params.chapter && verse.chapter !== params.chapter) return false;
+      return true;
+    });
+  }
+
+  async getVerseById(id: string): Promise<Verse | null> {
+    return verses.find((v) => v.id === id) ?? null;
+  }
+
+  async listLenses(): Promise<LensMeta[]> {
+    return lenses;
+  }
+
+  async listInterpretations(verseId: string): Promise<Interpretation[]> {
+    return interpretations.filter((interp) => interp.verseId === verseId);
+  }
+
+  async listSymbols(): Promise<SymbolEntry[]> {
+    return symbols;
+  }
+
+  async getSymbolById(id: string): Promise<SymbolEntry | null> {
+    return symbols.find((symbol) => symbol.id === id) ?? null;
+  }
+
+  async listNotes(userId: string): Promise<Note[]> {
+    return notes.filter((note) => note.userId === userId);
+  }
+
+  async listDossiers(userId: string): Promise<Dossier[]> {
+    return dossiers.filter((dossier) => dossier.userId === userId);
+  }
+}
+
+export const repository = new InMemoryAdapter();

--- a/lib/adapters/postgresAdapter.ts
+++ b/lib/adapters/postgresAdapter.ts
@@ -1,0 +1,58 @@
+import { Repository } from '@/lib/repositories/base';
+import { Dossier, Interpretation, LensMeta, Note, SymbolEntry, UsageRecord, User, Verse, Version } from '@/lib/types';
+
+export class PostgresAdapter implements Repository {
+  constructor(private readonly options: { url: string }) {}
+
+  private notReady(): never {
+    throw new Error('PostgresAdapter no configurado en este entorno.');
+  }
+
+  async getUserById(_id: string): Promise<User | null> {
+    this.notReady();
+  }
+
+  async getOrCreateUsage(_userId: string, _date: string): Promise<UsageRecord> {
+    this.notReady();
+  }
+
+  async incrementUsage(_userId: string, _date: string): Promise<UsageRecord> {
+    this.notReady();
+  }
+
+  async listVersions(): Promise<Version[]> {
+    this.notReady();
+  }
+
+  async listVerses(_params: { versionId?: string; book?: string; chapter?: number }): Promise<Verse[]> {
+    this.notReady();
+  }
+
+  async getVerseById(_id: string): Promise<Verse | null> {
+    this.notReady();
+  }
+
+  async listLenses(): Promise<LensMeta[]> {
+    this.notReady();
+  }
+
+  async listInterpretations(_verseId: string): Promise<Interpretation[]> {
+    this.notReady();
+  }
+
+  async listSymbols(): Promise<SymbolEntry[]> {
+    this.notReady();
+  }
+
+  async getSymbolById(_id: string): Promise<SymbolEntry | null> {
+    this.notReady();
+  }
+
+  async listNotes(_userId: string): Promise<Note[]> {
+    this.notReady();
+  }
+
+  async listDossiers(_userId: string): Promise<Dossier[]> {
+    this.notReady();
+  }
+}

--- a/lib/adapters/supabaseAdapter.ts
+++ b/lib/adapters/supabaseAdapter.ts
@@ -1,0 +1,58 @@
+import { Repository } from '@/lib/repositories/base';
+import { Dossier, Interpretation, LensMeta, Note, SymbolEntry, UsageRecord, User, Verse, Version } from '@/lib/types';
+
+export class SupabaseAdapter implements Repository {
+  constructor(private readonly options: { projectUrl: string; anonKey: string }) {}
+
+  private notReady(): never {
+    throw new Error('SupabaseAdapter no configurado en este entorno.');
+  }
+
+  async getUserById(_id: string): Promise<User | null> {
+    this.notReady();
+  }
+
+  async getOrCreateUsage(_userId: string, _date: string): Promise<UsageRecord> {
+    this.notReady();
+  }
+
+  async incrementUsage(_userId: string, _date: string): Promise<UsageRecord> {
+    this.notReady();
+  }
+
+  async listVersions(): Promise<Version[]> {
+    this.notReady();
+  }
+
+  async listVerses(_params: { versionId?: string | undefined; book?: string | undefined; chapter?: number | undefined }): Promise<Verse[]> {
+    this.notReady();
+  }
+
+  async getVerseById(_id: string): Promise<Verse | null> {
+    this.notReady();
+  }
+
+  async listLenses(): Promise<LensMeta[]> {
+    this.notReady();
+  }
+
+  async listInterpretations(_verseId: string): Promise<Interpretation[]> {
+    this.notReady();
+  }
+
+  async listSymbols(): Promise<SymbolEntry[]> {
+    this.notReady();
+  }
+
+  async getSymbolById(_id: string): Promise<SymbolEntry | null> {
+    this.notReady();
+  }
+
+  async listNotes(_userId: string): Promise<Note[]> {
+    this.notReady();
+  }
+
+  async listDossiers(_userId: string): Promise<Dossier[]> {
+    this.notReady();
+  }
+}

--- a/lib/repositories/base.ts
+++ b/lib/repositories/base.ts
@@ -1,0 +1,16 @@
+import { Dossier, Interpretation, LensMeta, Note, SymbolEntry, UsageRecord, User, Verse, Version } from '@/lib/types';
+
+export interface Repository {
+  getUserById(id: string): Promise<User | null>;
+  getOrCreateUsage(userId: string, date: string): Promise<UsageRecord>;
+  incrementUsage(userId: string, date: string): Promise<UsageRecord>;
+  listVersions(): Promise<Version[]>;
+  listVerses(params: { versionId?: string; book?: string; chapter?: number }): Promise<Verse[]>;
+  getVerseById(id: string): Promise<Verse | null>;
+  listLenses(): Promise<LensMeta[]>;
+  listInterpretations(verseId: string): Promise<Interpretation[]>;
+  listSymbols(): Promise<SymbolEntry[]>;
+  getSymbolById(id: string): Promise<SymbolEntry | null>;
+  listNotes(userId: string): Promise<Note[]>;
+  listDossiers(userId: string): Promise<Dossier[]>;
+}

--- a/lib/services/auth.ts
+++ b/lib/services/auth.ts
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers';
+import { defaultUser } from '@/data/seeds';
+import { User } from '@/lib/types';
+
+const SESSION_COOKIE = 'biblioteca-session';
+
+export function getCurrentUser(): User {
+  const cookieStore = cookies();
+  const userId = cookieStore.get(SESSION_COOKIE)?.value;
+  if (!userId) {
+    cookieStore.set(SESSION_COOKIE, defaultUser.id, {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: false,
+      maxAge: 60 * 60 * 24
+    });
+  }
+  return defaultUser;
+}
+
+export function logout() {
+  const cookieStore = cookies();
+  cookieStore.delete(SESSION_COOKIE);
+}

--- a/lib/services/dataService.ts
+++ b/lib/services/dataService.ts
@@ -1,0 +1,12 @@
+import { repository as inMemoryRepository } from '@/lib/adapters/inMemoryAdapter';
+import { Repository } from '@/lib/repositories/base';
+
+let activeRepository: Repository = inMemoryRepository;
+
+export function setRepository(repo: Repository) {
+  activeRepository = repo;
+}
+
+export function getRepository(): Repository {
+  return activeRepository;
+}

--- a/lib/services/search.ts
+++ b/lib/services/search.ts
@@ -1,0 +1,116 @@
+import { getRepository } from '@/lib/services/dataService';
+import { SearchResponse, Verse } from '@/lib/types';
+
+interface SearchParams {
+  query: string;
+  filters?: Record<string, string>;
+}
+
+const STRONG_REGEX = /strong:([GH]\d+)/gi;
+const LENS_REGEX = /lente:([a-z_]+)/gi;
+const TYPE_REGEX = /tipo:(dato|tradicion)/gi;
+const BOOK_REGEX = /libro:([A-Za-zÁÉÍÓÚÜÑñ]+)/gi;
+const THEME_REGEX = /tema:([\wáéíóúñ]+)/gi;
+
+export async function searchVerses({ query, filters = {} }: SearchParams, userId: string): Promise<SearchResponse> {
+  const repo = getRepository();
+  const allVerses = await repo.listVerses({});
+  const normalized = query.trim().toLowerCase();
+  const tokens = normalized.split(/\s+/).filter(Boolean);
+
+  let filtered: Verse[] = allVerses.filter((verse) => {
+    if (!normalized) return true;
+    const haystack = `${verse.book} ${verse.chapter}:${verse.verse} ${verse.text}`.toLowerCase();
+    return tokens.every((token) => {
+      if (token.startsWith('"') && token.endsWith('"')) {
+        const phrase = token.replace(/"/g, '');
+        return haystack.includes(phrase.toLowerCase());
+      }
+      if (token.includes(':')) {
+        return true; // handled later
+      }
+      if (token.endsWith('*')) {
+        const stem = token.slice(0, -1);
+        return haystack.includes(stem);
+      }
+      if (token === 'or') {
+        return true;
+      }
+      if (token.startsWith('-')) {
+        return !haystack.includes(token.slice(1));
+      }
+      return haystack.includes(token);
+    });
+  });
+
+  const strongFilters = [...normalized.matchAll(STRONG_REGEX)].map((match) => match[1]);
+  if (strongFilters.length) {
+    filtered = filtered.filter((verse) => strongFilters.some((code) => verse.text.toLowerCase().includes(code.toLowerCase())));
+  }
+
+  const bookFilters = [...normalized.matchAll(BOOK_REGEX)].map((match) => match[1].toLowerCase());
+  if (bookFilters.length) {
+    filtered = filtered.filter((verse) => bookFilters.includes(verse.book.toLowerCase()));
+  }
+
+  const lensFilters = [...normalized.matchAll(LENS_REGEX)].map((match) => match[1]);
+  if (lensFilters.length) {
+    const verseIdsWithLens = new Set((await Promise.all(filtered.map((verse) => repo.listInterpretations(verse.id)))).flat()
+      .filter((interp) => lensFilters.includes(interp.lens))
+      .map((interp) => interp.verseId));
+    filtered = filtered.filter((verse) => verseIdsWithLens.has(verse.id));
+  }
+
+  const typeFilters = [...normalized.matchAll(TYPE_REGEX)].map((match) => match[1]);
+  if (typeFilters.length) {
+    const verseIds = new Set((await Promise.all(filtered.map((verse) => repo.listInterpretations(verse.id)))).flat()
+      .filter((interp) => typeFilters.includes(interp.kind))
+      .map((interp) => interp.verseId));
+    filtered = filtered.filter((verse) => verseIds.has(verse.id));
+  }
+
+  const themeFilters = [...normalized.matchAll(THEME_REGEX)].map((match) => match[1].toLowerCase());
+  if (themeFilters.length) {
+    const symbols = await repo.listSymbols();
+    const allowed = new Set(
+      symbols.filter((symbol) => themeFilters.includes(symbol.name.toLowerCase())).flatMap((symbol) => symbol.appearsIn)
+    );
+    filtered = filtered.filter((verse) => allowed.has(`${verse.book} ${verse.chapter}:${verse.verse}`));
+  }
+
+  const facets = buildFacets(filtered);
+  const pageSize = 20;
+  const response: SearchResponse = {
+    results: filtered.slice(0, pageSize),
+    facets,
+    paging: {
+      page: 1,
+      pageSize,
+      total: filtered.length
+    },
+    remainingSearches: await remainingSearches(userId)
+  };
+  return response;
+}
+
+async function remainingSearches(userId: string): Promise<number> {
+  const repo = getRepository();
+  const today = new Date().toISOString().split('T')[0];
+  const record = await repo.getOrCreateUsage(userId, today);
+  return Math.max(0, 3 - record.searches);
+}
+
+function buildFacets(verses: Verse[]): Record<string, Record<string, number>> {
+  const facets: Record<string, Record<string, number>> = {
+    libro: {},
+    testamento: {},
+    version: {}
+  };
+  verses.forEach((verse) => {
+    facets.libro[verse.book] = (facets.libro[verse.book] ?? 0) + 1;
+    const testament = verse.book === 'Juan' ? 'NT' : 'AT';
+    facets.testamento[testament] = (facets.testamento[testament] ?? 0) + 1;
+    facets.version[verse.versionId] = (facets.version[verse.versionId] ?? 0) + 1;
+  });
+  return facets;
+}

--- a/lib/services/usage.ts
+++ b/lib/services/usage.ts
@@ -1,0 +1,38 @@
+import { getRepository } from '@/lib/services/dataService';
+
+const DAILY_LIMIT = 3;
+
+export async function incrementSearches(userId: string) {
+  const repo = getRepository();
+  const today = new Date().toISOString().split('T')[0];
+  const record = await repo.getOrCreateUsage(userId, today);
+  if (record.searches >= DAILY_LIMIT) {
+    const reset = nextReset();
+    const secondsLeft = Math.max(0, Math.floor((reset.getTime() - Date.now()) / 1000));
+    const error = new Error('Límite diario alcanzado');
+    (error as any).statusCode = 429;
+    (error as any).retryAfter = secondsLeft;
+    throw error;
+  }
+  const updated = await repo.incrementUsage(userId, today);
+  return {
+    remaining: Math.max(0, DAILY_LIMIT - updated.searches),
+    resetAt: nextReset()
+  };
+}
+
+export async function remainingSearches(userId: string) {
+  const repo = getRepository();
+  const today = new Date().toISOString().split('T')[0];
+  const record = await repo.getOrCreateUsage(userId, today);
+  return {
+    remaining: Math.max(0, DAILY_LIMIT - record.searches),
+    resetAt: nextReset()
+  };
+}
+
+function nextReset(): Date {
+  const reset = new Date();
+  reset.setUTCHours(23, 59, 59, 999);
+  return reset;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,104 @@
+export type LensKind = 'dato' | 'tradicion';
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  avatarUrl?: string;
+  createdAt: string;
+}
+
+export interface Version {
+  id: string;
+  code: string;
+  name: string;
+  lang: string;
+  year: number;
+  license: string;
+}
+
+export interface Verse {
+  id: string;
+  versionId: string;
+  book: string;
+  chapter: number;
+  verse: number;
+  text: string;
+  searchVector?: string;
+}
+
+export interface Lemma {
+  id: string;
+  strong: string;
+  lang: string;
+  lemma: string;
+  morph?: string;
+}
+
+export interface SymbolEntry {
+  id: string;
+  name: string;
+  type: string;
+  definition: string;
+  sources: string[];
+  appearsIn: string[];
+  isTradition?: boolean;
+}
+
+export interface LensMeta {
+  code: string;
+  name: string;
+  description: string;
+  isTradition: boolean;
+}
+
+export interface Interpretation {
+  id: string;
+  verseId: string;
+  lens: string;
+  thesis: string;
+  bodyMd: string;
+  citations: string[];
+  sources: string[];
+  kind: LensKind;
+  confidence: number;
+  status: 'published' | 'draft' | 'no_conclusion';
+  createdAt: string;
+  explanation?: string;
+}
+
+export interface Note {
+  id: string;
+  userId: string;
+  verseId: string;
+  content: string;
+  tags: string[];
+  createdAt: string;
+}
+
+export interface Dossier {
+  id: string;
+  userId: string;
+  title: string;
+  bodyMd: string;
+  references: string[];
+  createdAt: string;
+}
+
+export interface UsageRecord {
+  id: string;
+  userId: string;
+  date: string;
+  searches: number;
+}
+
+export interface SearchResponse {
+  results: Verse[];
+  facets: Record<string, Record<string, number>>;
+  paging: {
+    page: number;
+    pageSize: number;
+    total: number;
+  };
+  remainingSearches: number;
+}

--- a/lib/utils/bookSlug.ts
+++ b/lib/utils/bookSlug.ts
@@ -1,0 +1,6 @@
+export function bookToSlug(book: string) {
+  return book
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[^a-z0-9]/g, '');
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,13 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    serverActions: true
+  },
+  env: {
+    AI_ENABLED: process.env.AI_ENABLED || 'false',
+    PAYMENTS_ENABLED: process.env.PAYMENTS_ENABLED || 'false'
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "biblioteca-esoterica",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "pdfkit": "0.15.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.10",
+    "@types/react": "18.2.39",
+    "@types/react-dom": "18.2.15",
+    "typescript": "5.4.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2018",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.cjs"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js + TypeScript application for "Biblioteca Esotérica" with SSR pages for login, búsqueda global, lectura, cuaderno e interpretación por lentes
- seed in-memory repositories with RVR1909 textos, glosario, seis lentes y ejemplos de interpretaciones cumpliendo la separación Dato/Tradición y exponer endpoints REST
- habilitar servicios clave (búsqueda con límite de 3 consultas diarias, exportación PDF, cuaderno/notas, adaptadores Supabase/Postgres preparados) y UI con contadores, facetas y pestañas de lentes

## Testing
- `npm run lint` *(fails: Next.js no está instalado en el entorno debido a restricciones de descarga del registro npm)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6919831791f083309e7226313649e964)