### PR TITLE
Add LRU cache implementation with unit tests

### DIFF
--- a/lru_cache.py
+++ b/lru_cache.py
@@ -1,0 +1,69 @@
+class Nodo:
+    def __init__(self, clave=None, valor=None):
+        self.clave = clave
+        self.valor = valor
+        self.prev = None
+        self.next = None
+
+
+class LRUCache:
+    def __init__(self, capacidad: int):
+        if capacidad <= 0:
+            raise ValueError("La capacidad debe ser mayor que 0.")
+        self.capacidad = capacidad
+        self.mapa = {}  # clave -> nodo
+
+        # Nodos centinela para simplificar inserciones/eliminaciones
+        self.head = Nodo()  # Más recientemente usado irá justo después de head
+        self.tail = Nodo()  # Menos recientemente usado irá justo antes de tail
+        self.head.next = self.tail
+        self.tail.prev = self.head
+
+    # --- Métodos internos de lista doble ---
+    def _agregar_al_frente(self, nodo: Nodo):
+        nodo.prev = self.head
+        nodo.next = self.head.next
+        self.head.next.prev = nodo
+        self.head.next = nodo
+
+    def _quitar_nodo(self, nodo: Nodo):
+        anterior = nodo.prev
+        siguiente = nodo.next
+        anterior.next = siguiente
+        siguiente.prev = anterior
+
+    def _mover_al_frente(self, nodo: Nodo):
+        self._quitar_nodo(nodo)
+        self._agregar_al_frente(nodo)
+
+    def _quitar_lru(self) -> Nodo:
+        # LRU = nodo antes de tail
+        lru = self.tail.prev
+        self._quitar_nodo(lru)
+        return lru
+
+    # --- API pública ---
+    def get(self, clave):
+        if clave not in self.mapa:
+            return -1  # O None, según prefieras
+        nodo = self.mapa[clave]
+        self._mover_al_frente(nodo)
+        return nodo.valor
+
+    def put(self, clave, valor):
+        if clave in self.mapa:
+            # Actualiza valor y marca como más reciente
+            nodo = self.mapa[clave]
+            nodo.valor = valor
+            self._mover_al_frente(nodo)
+            return
+
+        # Inserta nueva clave
+        nuevo = Nodo(clave, valor)
+        self.mapa[clave] = nuevo
+        self._agregar_al_frente(nuevo)
+
+        # Si excede capacidad, expulsar LRU
+        if len(self.mapa) > self.capacidad:
+            lru = self._quitar_lru()
+            del self.mapa[lru.clave]

--- a/test_lru_cache.py
+++ b/test_lru_cache.py
@@ -1,0 +1,29 @@
+from lru_cache import LRUCache
+
+
+def test_lru_basico():
+    cache = LRUCache(2)
+    cache.put(1, 1)
+    cache.put(2, 2)
+
+    assert cache.get(1) == 1
+
+    cache.put(3, 3)  # expulsa clave 2
+    assert cache.get(2) == -1
+
+    cache.put(4, 4)  # expulsa clave 1
+    assert cache.get(1) == -1
+    assert cache.get(3) == 3
+    assert cache.get(4) == 4
+
+
+def test_actualizacion_mueve_al_frente():
+    cache = LRUCache(2)
+    cache.put("a", 1)
+    cache.put("b", 2)
+    cache.put("a", 10)
+
+    cache.put("c", 3)  # debe expulsar b
+    assert cache.get("b") == -1
+    assert cache.get("a") == 10
+    assert cache.get("c") == 3


### PR DESCRIPTION
### Motivation
- Provide a simple, efficient LRU cache implementation for use in projects that need O(1) `get`/`put` semantics.
- Ensure correct eviction and recency behavior via automated tests to prevent regressions.

### Description
- Add `lru_cache.py` implementing `Nodo` and `LRUCache` with sentinel `head`/`tail` nodes and internal methods `_agregar_al_frente`, `_quitar_nodo`, `_mover_al_frente`, and `_quitar_lru` to manage a doubly linked list. 
- Validate `capacidad > 0` in the constructor and expose public `get` and `put` methods where `get` moves an entry to the front and `put` updates or inserts and evicts the least-recently-used entry when capacity is exceeded. 
- The implementation stores nodes in a hash map (`mapa`) for O(1) access and returns `-1` for missing keys. 
- Add `test_lru_cache.py` with `pytest` tests covering basic eviction and update-recency behavior. 

### Testing
- Run `pytest -q` which executed the test suite. 
- Test results: `2 passed` (tests passed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d23adefff88330a7412b7631cef32e)